### PR TITLE
github workflows dependent on branch

### DIFF
--- a/.github/workflows/push_dockerhub.yml
+++ b/.github/workflows/push_dockerhub.yml
@@ -1,0 +1,41 @@
+name: Dockerhub Push
+
+on:
+  workflow_run:
+    workflows: ["Run Tests"]
+    branches: [main]
+    types: 
+      - completed
+
+jobs:
+  build_and_push:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+          token: ${{ secrets.CI_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .  # Path to the Dockerfile
+          push: true
+          platforms: linux/arm/v6,linux/arm/v8,linux/arm64,linux/amd64
+          tags: |
+            zostaw/multiarch-home-page:latest
+            zostaw/multiarch-home-page:${{ github.sha }}

--- a/.github/workflows/test_docker.yml
+++ b/.github/workflows/test_docker.yml
@@ -1,13 +1,9 @@
-name: Docker Image CI
+name: Run Tests
 
-on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+on: [push, pull_request]
 
 jobs:
-  test:
+  test_page_initiation:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -49,34 +45,3 @@ jobs:
           name: reports
           path: reports
 
-  build:
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          submodules: true
-          token: ${{ secrets.CI_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v2
-        with:
-          context: .  # Path to the Dockerfile
-          push: true
-          platforms: linux/arm/v6,linux/arm/v8,linux/arm64,linux/amd64
-          tags: |
-            zostaw/multiarch-home-page:latest
-            zostaw/multiarch-home-page:${{ github.sha }}


### PR DESCRIPTION
Tests should be executed for all branches, 
but dockerhub push only in main, when tests completed.
The workflows are now devided:
- test_docker.yml - executed for *all branches*
- push_dockerhub.yml - executed after test_docker completion for *main*